### PR TITLE
chore:Removal of deprecated services

### DIFF
--- a/lib/base/networking/apis/tumCabeApi/tum_cabe_api.dart
+++ b/lib/base/networking/apis/tumCabeApi/tum_cabe_api.dart
@@ -64,40 +64,8 @@ class TumCabeApi extends Api {
         return "${path}news/sources";
       case TumCabeServiceNewsAlert _:
         return "${path}news/alert";
-      case TumCabeServiceRoomSearch _:
-        // TODO:
-        return path;
-        /*return "roomfinder/room/search/${roomSearch.query.addingPercentEncoding(
-            withAllowedCharacters: .afURLQueryAllowed) ?? ""}";*/
-      case TumCabeServiceRoomMaps _:
-        // TODO:
-        return path;
-        /*return "roomfinder/room/availableMaps/${roomMaps.room.addingPercentEncoding(
-            withAllowedCharacters: .afURLQueryAllowed) ?? ""}";*/
-      case TumCabeServiceRoomCoordinates roomCoordinates:
-        return "${path}roomfinder/room/coordinates/${roomCoordinates.room}";
-      case TumCabeServiceDefaultMap defaultMap:
-        return "${path}roomfinder/room/defaultMap/${defaultMap.room}";
-      case TumCabeServiceMapImage mapImage:
-        return "${path}roomfinder/room/map/${mapImage.room}/${mapImage.id}";
       case TumCabeServiceRegisterDevice registerDevice:
         return "${path}device/register/${registerDevice.publicKey}";
-      case TumCabeServiceEvents _:
-        return "${path}event/list";
-      case TumCabeServiceMyEvents _:
-        return "${path}event/ticket/my";
-      case TumCabeServiceTicketTypes ticketTypes:
-        return "${path}event/ticket/type/${ticketTypes.event}";
-      case TumCabeServiceTicketStats ticketStats:
-        return "${path}event/ticket/type/${ticketStats.event}";
-      case TumCabeServiceTicketReservation _:
-        return "${path}event/ticket/reserve";
-      case TumCabeServiceTicketReservationCancellation _:
-        return "${path}event/ticket/reserve/cancel";
-      case TumCabeServiceTicketPurchase _:
-        return "${path}event/ticket/payment/stripe/purchase";
-      case TumCabeServiceStripeKey _:
-        return "${path}event/ticket/payment/stripe/ephemeralkey";
     }
   }
 

--- a/lib/base/networking/apis/tumCabeApi/tum_cabe_api_service.dart
+++ b/lib/base/networking/apis/tumCabeApi/tum_cabe_api_service.dart
@@ -16,63 +16,8 @@ class TumCabeServiceNewsSources extends TumCabeService {}
 
 class TumCabeServiceNewsAlert extends TumCabeService {}
 
-class TumCabeServiceRoomSearch extends TumCabeService {
-  final String query;
-
-  TumCabeServiceRoomSearch({required this.query});
-}
-
-class TumCabeServiceRoomMaps extends TumCabeService {
-  final String room;
-
-  TumCabeServiceRoomMaps({required this.room});
-}
-
-class TumCabeServiceRoomCoordinates extends TumCabeService {
-  final String room;
-
-  TumCabeServiceRoomCoordinates({required this.room});
-}
-
-class TumCabeServiceMapImage extends TumCabeService {
-  final int id;
-  final String room;
-
-  TumCabeServiceMapImage({required this.id, required this.room});
-}
-
-class TumCabeServiceDefaultMap extends TumCabeService {
-  final String room;
-
-  TumCabeServiceDefaultMap({required this.room});
-}
-
 class TumCabeServiceRegisterDevice extends TumCabeService {
   final String publicKey;
 
   TumCabeServiceRegisterDevice({required this.publicKey});
 }
-
-class TumCabeServiceEvents extends TumCabeService {}
-
-class TumCabeServiceMyEvents extends TumCabeService {}
-
-class TumCabeServiceTicketTypes extends TumCabeService {
-  final int event;
-
-  TumCabeServiceTicketTypes({required this.event});
-}
-
-class TumCabeServiceTicketStats extends TumCabeService {
-  final int event;
-
-  TumCabeServiceTicketStats({required this.event});
-}
-
-class TumCabeServiceTicketReservation extends TumCabeService {}
-
-class TumCabeServiceTicketReservationCancellation extends TumCabeService {}
-
-class TumCabeServiceTicketPurchase extends TumCabeService {}
-
-class TumCabeServiceStripeKey extends TumCabeService {}

--- a/lib/placesComponent/services/studyrooms_service.dart
+++ b/lib/placesComponent/services/studyrooms_service.dart
@@ -1,10 +1,7 @@
-import 'package:campus_flutter/base/networking/apis/tumCabeApi/tum_cabe_api.dart';
-import 'package:campus_flutter/base/networking/apis/tumCabeApi/tum_cabe_api_service.dart';
 import 'package:campus_flutter/base/networking/apis/tumDevAppApi/tum_dev_app_api.dart';
 import 'package:campus_flutter/base/networking/apis/tumDevAppApi/tum_dev_app_api_service.dart';
 import 'package:campus_flutter/base/networking/protocols/main_api.dart';
 import 'package:campus_flutter/placesComponent/model/studyRooms/study_room_data.dart';
-import 'package:campus_flutter/placesComponent/model/studyRooms/study_room_image_mapping.dart';
 import 'package:campus_flutter/providers_get_it.dart';
 
 class StudyRoomsService {
@@ -13,17 +10,6 @@ class StudyRoomsService {
     final response = await mainApi.makeRequest<StudyRoomData, TumDevAppApi>(
         TumDevAppApi(tumDevAppService: TumDevAppServiceRooms()),
         StudyRoomData.fromJson,
-        forcedRefresh
-    );
-
-    return (response.saved, response.data);
-  }
-
-  static Future<(DateTime?, StudyRoomImageMapping)> fetchMap(bool forcedRefresh, String room) async {
-    MainApi mainApi = getIt<MainApi>();
-    final response = await mainApi.makeRequest<StudyRoomImageMapping, TumCabeApi>(
-        TumCabeApi(tumCabeService: TumCabeServiceRoomMaps(room: room)),
-        StudyRoomImageMapping.fromJson,
         forcedRefresh
     );
 


### PR DESCRIPTION
This PR removes services that will not be available after the v1-backend shutdown.

For the ticketing: This has not been used in years => removing this is a good call
The roomfinding apis have been entirely replaced by navigatum.
